### PR TITLE
Use inputs from payload by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,27 +2,23 @@ A GitHub Action to easily send the result of a health check to the [Service Cata
 
 ## Usage
 
-```yaml
-    - uses: clearwind-ca/get-payload@v1
-    # Do something with the payload
-    # Assumes that the result will be in /tmp/service-catalog-payload.json
-    - uses: clearwind-ca/send-payload@v1
-      env:
-        SERVICE_CATALOG_TOKEN: ${{ secrets.SERVICE_CATALOG_TOKEN }}
-```
-
 With inputs:
 
 ```yaml
-    - uses: clearwind-ca/get-payload@v1
-    # Do something with the payload
-    # Assumes that the result will be in /tmp/service-catalog-payload.json
     - uses: clearwind-ca/send-result@inputs
       env:
         SERVICE_CATALOG_TOKEN: ${{ secrets.SERVICE_CATALOG_TOKEN }}
       with:
         result: "fail"
         message: "this didn't work out i'm afraid"
+```
+
+With a file written at the default location.
+
+```yaml
+    - uses: clearwind-ca/send-payload@v1
+      env:
+        SERVICE_CATALOG_TOKEN: ${{ secrets.SERVICE_CATALOG_TOKEN }}
 ```
 
 ## Required secrets
@@ -43,6 +39,8 @@ This secret must exist so that it can authenticate with the Service Catalog.
 If `payload_file` and `result_file` are not specified, then they will use the defaults above.
 
 The `payload_file` is the result of using `get-payload` and will place the payload in the correct place for this Action to consume.
+
+If the `payload_file` is not specified and the default file is not present then it will use the input from the `repository_dispatch` event, if the `repository_dispatch` event payload exists.
 
 If the `result_file` is not specified and the default file is not present then it will use the following inputs will be used.
 

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: 'The filename of the payload'
     required: false
     default: '/tmp/service-catalog-payload.json'
+  payload:
+    description: 'The payload of the service catalog request'
+    required: false
+    default: ${{ github.event.client_payload.data }}
   result_file:
     description: 'The filename of the result'
     required: false

--- a/result.js
+++ b/result.js
@@ -2,19 +2,35 @@ const fs = require('fs');
 const https = require('https');
 const querystring = require('querystring');
 
-let payload = JSON.parse(fs.readFileSync(process.env.INPUT_PAYLOAD_FILE, 'utf8'));
-let parsedFile = false;
+let parsedPayloadFile = false;
+let payload = {};
+
+if (process.env.INPUT_PAYLOAD_FILE) {
+  console.log(`Reading ${process.env.INPUT_PAYLOAD_FILE}`)
+  if (fs.existsSync(process.env.INPUT_PAYLOAD_FILE)) {
+    payload = JSON.parse(fs.readFileSync(process.env.INPUT_PAYLOAD_FILE, 'utf8'));
+    parsedPayloadFile = true;
+  }
+}
+
+if (!parsedPayloadFile) {
+  console.log(`Using individual payload input.`);
+  payload = Buffer.from(process.env.INPUT_PAYLOAD, 'base64').toString('utf-8');
+  payload = JSON.parse(payload);
+}
+
+let parsedResultFile = false;
 let result = {};
 
 if (process.env.INPUT_RESULT_FILE) {
   console.log(`Reading ${process.env.INPUT_RESULT_FILE}`)
   if (fs.existsSync(process.env.INPUT_RESULT_FILE)) {
     result = JSON.parse(fs.readFileSync(process.env.INPUT_RESULT_FILE, 'utf8'));
-    parsedFile = true;
+    parsedResultFile = true;
   }
 }
 
-if (!parsedFile) {
+if (!parsedResultFile) {
   console.log(`Using individual inputs.`);
   result = {
     "result": process.env.INPUT_RESULT,


### PR DESCRIPTION
This makes `get-payload` optional and not needed to send a result if the Action has been triggered by the repository dispatch.